### PR TITLE
Remove files for docs and tests from coverage

### DIFF
--- a/packages/espresso-block-explorer-components/vite.config.ts
+++ b/packages/espresso-block-explorer-components/vite.config.ts
@@ -28,6 +28,7 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json-summary', 'json'],
       reportOnFailure: true,
+      exclude: ['**/__docs__/**', '**/__test__/**'],
     },
   },
 });


### PR DESCRIPTION
Removes __docs__ and __test__ sub files from consideration for code coverage.