### PR TITLE
Add LocaleProviders Context Components

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/contexts/LocaleProvider.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/LocaleProvider.tsx
@@ -1,0 +1,43 @@
+import React, { createContext } from 'react';
+
+/**
+ * LocaleProvider is a Context that provides the current locale that has been
+ * determined for the current user.  Other contexts will consume this context
+ * and provide more contexts. Almost all of these contexts are determined to
+ * be localization and internationalization based.
+ *
+ * Examples:
+ *  Need to provide a number formatter, you'd only want to have to instantiate
+ *  a single copy, and then make it available to every consumer within the tree.
+ */
+const CurrentLocale = createContext(navigator.language);
+export { CurrentLocale };
+
+export interface ProvideLocaleProps {
+  locale: string;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * OverrideLocale is a [FunctionalComponent] that will provide the given locale
+ * to all of the descendant components within the tree.
+ * @param props The props of the OverrideLocale widget should contain children
+ *   nodes as well as the locale to replace in the sub-tree.
+ */
+export const OverrideLocale: React.FC<ProvideLocaleProps> = (props) => (
+  <CurrentLocale.Provider value={props.locale}>
+    {props.children}
+  </CurrentLocale.Provider>
+);
+
+/**
+ * ProvideNavigatorLanguage is a [FunctionalComponent] that will provide the
+ * locale retrieved from the `navigator.language` value.
+ */
+export const ProvideNavigatorLanguage: React.FC<
+  Omit<ProvideLocaleProps, 'locale'>
+> = (props) => (
+  <CurrentLocale.Provider value={navigator.language}>
+    {props.children}
+  </CurrentLocale.Provider>
+);

--- a/packages/espresso-block-explorer-components/src/components/contexts/__test__/LocaleProvider.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/__test__/LocaleProvider.test.tsx
@@ -1,0 +1,65 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  CurrentLocale,
+  OverrideLocale,
+  ProvideNavigatorLanguage,
+} from '../LocaleProvider';
+
+let localLocale: null | string = null;
+const ConsumeLocaleComponent: React.FC = () => {
+  const locale = React.useContext(CurrentLocale);
+  localLocale = locale;
+  return <div />;
+};
+
+beforeEach(() => {
+  localLocale = null;
+});
+
+describe('Locale Provider', () => {
+  describe('No Provider', () => {
+    it('should match navigator.languages', () => {
+      expect(localLocale).toEqual(null);
+      render(<ConsumeLocaleComponent />);
+      expect(localLocale).toEqual(navigator.language);
+    });
+  });
+
+  describe('Provide Navigator Language', () => {
+    it('should match navigator.language', () => {
+      expect(localLocale).toEqual(null);
+      render(
+        <ProvideNavigatorLanguage>
+          <ConsumeLocaleComponent />
+        </ProvideNavigatorLanguage>
+      );
+      expect(localLocale).toEqual(navigator.language);
+    });
+  });
+
+  describe('Provide Navigator Language', () => {
+    it('should match navigator.language', () => {
+      expect(localLocale).toEqual(null);
+      render(
+        <ProvideNavigatorLanguage>
+          <OverrideLocale locale="hi">
+            <ConsumeLocaleComponent />
+          </OverrideLocale>
+        </ProvideNavigatorLanguage>
+      );
+      expect(localLocale).toEqual('hi');
+
+      render(
+        <ProvideNavigatorLanguage>
+          <OverrideLocale locale="en-FR">
+            <ConsumeLocaleComponent />
+          </OverrideLocale>
+        </ProvideNavigatorLanguage>
+      );
+      expect(localLocale).toEqual('en-FR');
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/contexts/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/contexts/index.ts
@@ -1,0 +1,1 @@
+export * from './LocaleProvider';

--- a/packages/espresso-block-explorer-components/src/components/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/index.ts
@@ -1,3 +1,4 @@
+export * from './contexts';
 export * from './text';
 export * from './typography';
 export * from './visual';


### PR DESCRIPTION
This PR adds the `CurrentLocale` `Context` in order to quickly reference the authority `Locale` within the component tree.  It defaults to the `navigator.locale` for convenience.

In addition this provides two components `OverrideLocale`, and `ProvideNavigatorLanguage`.

The first is `OverrideLocale` which will change the `CurrentLocale` `Context` to
have the value passed into the `locale` as the new `locale` for the sub-tree underneath the `OverrideLocale` `component`.

The second is `ProvideNavigatorLanguage` which will change the `CurrentLocale` `Context` to what is currently stored
within the `navigator.language`.
