### PR TITLE
Add the Now Context to the page

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/contexts/NowProvider.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/NowProvider.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+
+/**
+ * Now is a context that is meant to provide the current Date, or some
+ * reference for whatever 'now' is considered to be.
+ */
+export const Now = React.createContext(new Date());
+
+export interface ProvideTickEverySecondProps {
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * ProvideTickEverySecond is a component that will update the Now context
+ * every second.
+ *
+ * @todo this setInterval **might** be called at most once before being
+ *       cleared.  Perhaps a setTimeout could be more appropriate in such
+ *       cases.  It would also allow us to attempt to provide the next second
+ *       at the top of the second instead of just every second.
+ */
+export const ProvideTickEverySecond: React.FC<ProvideTickEverySecondProps> = (
+  props,
+) => {
+  const [state, setState] = React.useState(new Date());
+
+  React.useEffect(() => {
+    // mounted,
+    const int = setInterval(() => {
+      // Update the interval every state
+      setState(new Date());
+    }, 1000);
+
+    return () => {
+      // Unmounted
+      clearInterval(int);
+    };
+  });
+
+  return <Now.Provider {...props} value={state} />;
+};

--- a/packages/espresso-block-explorer-components/src/components/contexts/__test__/NowProvider.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/__test__/NowProvider.test.tsx
@@ -1,0 +1,53 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { Now, ProvideTickEverySecond } from '../NowProvider';
+
+async function sleep(ms: number) {
+  return new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      clearTimeout(timeout);
+      resolve();
+    }, ms);
+  });
+}
+
+let localNow: null | Date = null;
+const ConsumeNowComponent: React.FC = () => {
+  localNow = React.useContext(Now);
+  return <div />;
+};
+
+beforeEach(() => {
+  localNow = null;
+});
+
+describe('Now Provider', () => {
+  describe('No Provider', () => {
+    it('should provide something', () => {
+      expect(localNow).toEqual(null);
+      render(<ConsumeNowComponent />);
+      expect(localNow).not.toBeNull();
+    });
+  });
+
+  describe('Override Path Resolver', () => {
+    it('should change every second', async () => {
+      expect(localNow).toEqual(null);
+      render(
+        <ProvideTickEverySecond>
+          <ConsumeNowComponent />
+        </ProvideTickEverySecond>,
+      );
+      const date1 = localNow;
+      expect(localNow).not.toBeNull();
+
+      await sleep(2000);
+      const date2 = localNow;
+      expect(localNow).not.toBeNull();
+
+      expect(date1?.valueOf()).not.equal(date2?.valueOf());
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/contexts/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/contexts/index.ts
@@ -1,1 +1,2 @@
 export * from './LocaleProvider';
+export * from './NowProvider';


### PR DESCRIPTION
The Now Context is a simple context that is meant for holding the current concept of what "Now" is in terms of a Date.

In addition to defining the context, this also defines a component that will automatically update the NowContext every second.