### PR TITLE
Add AsyncSnapshot

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/contexts/DataProvider.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/DataProvider.tsx
@@ -1,0 +1,20 @@
+import React, { createContext } from 'react';
+
+const DataContext = createContext<unknown>(null);
+export { DataContext };
+
+export interface SetDataProps<Data> {
+  data: Data;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * SetData is a Components whose sole purpose is to populate a DataContext
+ * with the provided data.  At such a level we are unable to make any
+ * type assertion about the data being provided.
+ */
+export const SetData: React.FC<SetDataProps<unknown>> = (props) => (
+  <DataContext.Provider value={props.data}>
+    {props.children}
+  </DataContext.Provider>
+);

--- a/packages/espresso-block-explorer-components/src/components/contexts/ErrorProvider.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/ErrorProvider.tsx
@@ -1,0 +1,15 @@
+import React, { createContext } from 'react';
+
+const ErrorContext = createContext<unknown>(null);
+export { ErrorContext };
+
+export interface SetErrorProps {
+  error: unknown;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+export const SetError: React.FC<SetErrorProps> = (props) => (
+  <ErrorContext.Provider value={props.error}>
+    {props.children}
+  </ErrorContext.Provider>
+);

--- a/packages/espresso-block-explorer-components/src/components/contexts/LoadingProvider.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/LoadingProvider.tsx
@@ -1,0 +1,15 @@
+import React, { createContext } from 'react';
+
+const LoadingContext = createContext(false);
+export { LoadingContext };
+
+export interface SetLoadingProps {
+  loading: boolean;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+export const SetLoading: React.FC<SetLoadingProps> = (props) => (
+  <LoadingContext.Provider value={props.loading}>
+    {props.children}
+  </LoadingContext.Provider>
+);

--- a/packages/espresso-block-explorer-components/src/components/contexts/__test__/DataProvider.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/__test__/DataProvider.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { DataContext, SetData } from '../DataProvider';
+
+let localData: null | unknown = null;
+const ConsumeDataComponent: React.FC = () => {
+  localData = React.useContext(DataContext);
+  return <div />;
+};
+
+beforeEach(() => {
+  localData = null;
+});
+
+describe('Data Provider', () => {
+  describe('No Provider', () => {
+    it('should provide null', () => {
+      expect(localData).toEqual(null);
+      render(<ConsumeDataComponent />);
+      expect(localData).toEqual(null);
+    });
+  });
+
+  describe('Set Data', () => {
+    it('should change when data provided changes', async () => {
+      expect(localData).toEqual(null);
+      render(
+        <SetData data={1}>
+          <ConsumeDataComponent />
+        </SetData>,
+      );
+      const data1 = localData;
+      expect(localData).not.toBeNull();
+
+      render(
+        <SetData data={'hello'}>
+          <ConsumeDataComponent />
+        </SetData>,
+      );
+      const data2 = localData;
+      expect(localData).not.toBeNull();
+
+      expect(data1).not.equal(data2);
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/contexts/__test__/ErrorProvider.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/__test__/ErrorProvider.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { ErrorContext, SetError } from '../ErrorProvider';
+
+let localError: null | unknown = null;
+const ConsumeErrorComponent: React.FC = () => {
+  localError = React.useContext(ErrorContext);
+  return <div />;
+};
+
+beforeEach(() => {
+  localError = null;
+});
+
+describe('Error Provider', () => {
+  describe('No Provider', () => {
+    it('should provide null', () => {
+      expect(localError).toEqual(null);
+      render(<ConsumeErrorComponent />);
+      expect(localError).toEqual(null);
+    });
+  });
+
+  describe('Set Data', () => {
+    it('should change when data provided changes', async () => {
+      expect(localError).toEqual(null);
+      render(
+        <SetError error={new Error('error 1')}>
+          <ConsumeErrorComponent />
+        </SetError>,
+      );
+      const loading1 = localError;
+      expect(localError).not.toBeNull();
+
+      render(
+        <SetError error={new TypeError('type error 1')}>
+          <ConsumeErrorComponent />
+        </SetError>,
+      );
+      const loading2 = localError;
+      expect(localError).not.toBeNull();
+
+      expect(loading1).not.equal(loading2);
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/contexts/__test__/LoadingProvider.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/contexts/__test__/LoadingProvider.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { LoadingContext, SetLoading } from '../LoadingProvider';
+
+let localLoading: null | boolean = null;
+const ConsumeLoadingComponent: React.FC = () => {
+  localLoading = React.useContext(LoadingContext);
+  return <div />;
+};
+
+beforeEach(() => {
+  localLoading = null;
+});
+
+describe('Data Provider', () => {
+  describe('No Provider', () => {
+    it('should provide false', () => {
+      expect(localLoading).toEqual(null);
+      render(<ConsumeLoadingComponent />);
+      expect(localLoading).toEqual(false);
+    });
+  });
+
+  describe('Set Data', () => {
+    it('should change when data provided changes', async () => {
+      expect(localLoading).toEqual(null);
+      render(
+        <SetLoading loading={true}>
+          <ConsumeLoadingComponent />
+        </SetLoading>,
+      );
+      const loading1 = localLoading;
+      expect(localLoading).not.toBeNull();
+
+      render(
+        <SetLoading loading={false}>
+          <ConsumeLoadingComponent />
+        </SetLoading>,
+      );
+      const loading2 = localLoading;
+      expect(localLoading).not.toBeNull();
+
+      expect(loading1).not.equal(loading2);
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/AsyncSnapshot.ts
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/AsyncSnapshot.ts
@@ -1,0 +1,147 @@
+export enum AsyncState {
+  none,
+  waiting,
+  active,
+  done,
+}
+
+/**
+ * AsyncSnapshot represents a snapshot within an Asynchronous process.  This
+ * snapshot can be used to represent the async processes for Promise or
+ * AsyncIterators / AsyncIterables.
+ *
+ * AsyncSnapshot is a base class that more definitive states will represent.
+ * AsyncSnapshot cannot be built directly itself, but it does have several
+ * static functions that act as constructors to the various different
+ * representations with the relevant arguments populated.
+ */
+export abstract class AsyncSnapshot<T> {
+  get asyncState(): AsyncState {
+    return AsyncState.none;
+  }
+
+  get data(): undefined | T {
+    return undefined;
+  }
+
+  get error(): undefined | unknown {
+    return undefined;
+  }
+
+  get hasData(): boolean {
+    return false;
+  }
+
+  get hasError(): boolean {
+    return false;
+  }
+
+  /**
+   * nothing creates an AsyncSnapshot with the "nothing" state. It is provided
+   * for convenience but ultimately will likely not be utilized in a normal
+   * asynchronous process.
+   */
+  public static nothing<T>() {
+    return new AsyncSnapshotNothing<T>();
+  }
+
+  /**
+   * waiting creates an AsyncSnapshot with the "waiting" state.  It is meant
+   * to indicate the an Async process has begun, but has not yet resolved.
+   */
+  public static waiting<T>() {
+    return new AsyncSnapshotWaiting<T>();
+  }
+
+  /**
+   * withData creates an AsyncSnapshot with the given state and data.  This
+   * will primarily be used with the states "done" indicating that no more
+   * data updates will follow, or "active" indicating that there may be more
+   * data updates.
+   */
+  public static withData<T>(asyncState: AsyncState, data: T) {
+    return new AsyncSnapshotData(asyncState, data);
+  }
+
+  /**
+   * withError creates an AsyncSnapshot with the given state and error.  This
+   * will primarily be used with the states "done" indicating that no more
+   * updates will follow, or "active" indicating that there may be more updates.
+   * In this case it's most likely that any errors would prevent further
+   * updates.
+   */
+  public static withError(asyncState: AsyncState, error: unknown) {
+    return new AsyncSnapshotError(asyncState, error);
+  }
+}
+
+/**
+ * AsyncSnapshotNothing represents a non-state of an AsyncSnapshot.  It is
+ * provided for convenience, but ultimately should not be used.
+ */
+class AsyncSnapshotNothing<T> extends AsyncSnapshot<T> {}
+
+/**
+ * AsyncSnapshotWaiting represents the waiting state of an AsyncSnapshot. It
+ * indicates that the async process has not yet yielded any data.
+ */
+class AsyncSnapshotWaiting<T> extends AsyncSnapshot<T> {
+  get asyncState(): AsyncState {
+    return AsyncState.waiting;
+  }
+}
+
+/**
+ * AsyncSnapshotError represents an AsyncSnapshot with an error populated.  It
+ * indicates that an error has occurred, and that we do not have data.
+ */
+class AsyncSnapshotError<T> extends AsyncSnapshot<T> {
+  private readonly _connectionState: AsyncState;
+  private readonly _error: unknown;
+
+  public get asyncState(): AsyncState {
+    return this._connectionState;
+  }
+
+  public get error(): undefined | unknown {
+    return this._error;
+  }
+
+  constructor(connectionState: AsyncState, error: unknown) {
+    super();
+    this._connectionState = connectionState;
+    this._error = error;
+  }
+
+  get hasError(): boolean {
+    return true;
+  }
+}
+
+/**
+ * AsyncSnapshotData represents an AsyncSnapshot with data populated. It
+ * indicates that we have data from the Async process, and that we do not
+ * currently have an error.
+ */
+class AsyncSnapshotData<T> extends AsyncSnapshot<T> {
+  private readonly _connectionState: AsyncState;
+  private readonly _data: T;
+
+  public get asyncState(): AsyncState {
+    return this._connectionState;
+  }
+
+  public get data(): undefined | T {
+    return this._data;
+  }
+
+  constructor(connectionState: AsyncState, data: T) {
+    super();
+    this._connectionState = connectionState;
+    this._data = data;
+  }
+
+  get hasData(): boolean {
+    return true;
+  }
+}

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/AsyncSnapshotContext.ts
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/AsyncSnapshotContext.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+import { AsyncSnapshot } from './AsyncSnapshot';
+
+/**
+ * AsyncSnapshotContext is a React Context that holds an AsyncSnapshot state.
+ * This is useful for passing AsyncSnapshots down the component tree.
+ */
+export const AsyncSnapshotContext = React.createContext<AsyncSnapshot<unknown>>(
+  AsyncSnapshot.nothing()
+);

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/PromiseBuilder.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/PromiseBuilder.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { AsyncSnapshot } from './AsyncSnapshot';
+import { AsyncSnapshotContext } from './AsyncSnapshotContext';
+import PromiseResolver from './PromiseResolver';
+
+/**
+ * The Props of a Builder component passed to the builder of a PromiseBuilder.
+ */
+export type PromiseBuilderBuilderProps<T> = {
+  snapshot: AsyncSnapshot<T>;
+};
+
+/**
+ * PromiseBuilder requires a promise and a builder that accepts AsyncSnapshots
+ * of the Promise result.
+ */
+export interface PromiseBuilderProps<T> {
+  promise: Promise<T>;
+  builder: React.ComponentType<PromiseBuilderBuilderProps<T>>;
+}
+
+function consumeSnapshot(
+  component: React.ComponentType<PromiseBuilderBuilderProps<unknown>>
+): React.FC {
+  return function ConsumeSnapshot() {
+    const snapshot = React.useContext(AsyncSnapshotContext);
+    return React.createElement(component, { snapshot });
+  };
+}
+
+/**
+ * PromiseBuilder is a component that can resolve the Async nature of promise
+ * for components.
+ */
+const PromiseBuilder: React.FC<PromiseBuilderProps<unknown>> = (props) => {
+  return (
+    <PromiseResolver promise={props.promise}>
+      {React.createElement(consumeSnapshot(props.builder))}
+    </PromiseResolver>
+  );
+};
+
+export default PromiseBuilder;

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/PromiseResolver.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/PromiseResolver.tsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import { AsyncSnapshot, AsyncState } from './AsyncSnapshot';
+import { AsyncSnapshotContext } from './AsyncSnapshotContext';
+import ProvideAsyncStates from './ProvideAsyncStates';
+
+export interface PromiseBuilderProps<T> {
+  promise: Promise<T>;
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * PromiseResolverState represents the internal state of the PromiseBuilder.
+ */
+interface PromiseResolverState<T> {
+  promise: Promise<T>;
+  state: AsyncSnapshot<T>;
+}
+
+/**
+ * PromiseResolver converts the given promise into distinct AsyncSnapshot
+ * states and passes it to the given children components via the
+ * AsyncSnapshotContext React Context.  It also automatically expands the
+ * data in the AsyncSnapshot to the Data, Loading, and Error contexts using
+ * the ProvideAsyncStates component.  As such, any descendant component will
+ * have access to what is needed via the AsyncSnapshotContext, LoadingContext,
+ * DataContext, or ErrorContext contexts.
+ */
+const PromiseResolver: React.FC<PromiseBuilderProps<unknown>> = (props) => {
+  const promise = props.promise;
+  const [state, setState] = React.useState<PromiseResolverState<unknown>>({
+    promise,
+    state: AsyncSnapshot.waiting(),
+  });
+
+  const snapshot = state.state;
+
+  if (snapshot.asyncState == AsyncState.waiting) {
+    promise.then(
+      (data) =>
+        setState({
+          promise,
+          state: AsyncSnapshot.withData(AsyncState.done, data),
+        }),
+      (error) =>
+        setState({
+          promise,
+          state: AsyncSnapshot.withError(AsyncState.done, error),
+        })
+    );
+  }
+
+  if (state.promise !== promise) {
+    setState({
+      promise,
+      state: AsyncSnapshot.waiting(),
+    });
+  }
+
+  return (
+    <AsyncSnapshotContext.Provider value={snapshot}>
+      <ProvideAsyncStates>{props.children}</ProvideAsyncStates>
+    </AsyncSnapshotContext.Provider>
+  );
+};
+
+export default PromiseResolver;

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/ProvideAsyncStates.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/ProvideAsyncStates.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { SetData } from '../../contexts/DataProvider';
+import { SetError } from '../../contexts/ErrorProvider';
+import { SetLoading } from '../../contexts/LoadingProvider';
+import { AsyncState } from './AsyncSnapshot';
+import { AsyncSnapshotContext } from './AsyncSnapshotContext';
+
+export interface ProvideAsyncStatesProps {
+  children?: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * ProvideAsyncStates consumes an ancestor AsyncSnapshotContext and will
+ * provide a LoadingContext, ErrorContext, and DataContext for consumption
+ * by ancestor components.
+ */
+const ProvideAsyncStates: React.FC<ProvideAsyncStatesProps> = (props) => {
+  const snapshot = React.useContext(AsyncSnapshotContext);
+
+  return (
+    <SetLoading loading={snapshot.asyncState === AsyncState.waiting}>
+      <SetError error={snapshot.error}>
+        <SetData data={snapshot.data}>{props.children}</SetData>
+      </SetError>
+    </SetLoading>
+  );
+};
+
+export default ProvideAsyncStates;

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/__docs__/PromiseResolver.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/__docs__/PromiseResolver.stories.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import PromiseResolverComp from '../PromiseResolver';
+import { AsyncSnapshotContext } from '../AsyncSnapshotContext';
+import { AsyncState } from '../AsyncSnapshot';
+import Text from '../../../text/Text';
+
+async function sleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(() => {
+      clearTimeout(timeout);
+
+      resolve();
+    }, milliseconds);
+  });
+}
+
+interface ExampleProps {
+  value: string;
+  milliseconds: number;
+}
+
+const ConsumeSnapshot: React.FC = () => {
+  const snapshot = React.useContext(AsyncSnapshotContext);
+
+  if (snapshot.asyncState === AsyncState.waiting) {
+    return <Text text="Loading..." />;
+  }
+
+  const data = snapshot.data;
+  return <Text text={String(data)} />;
+};
+
+const Example: React.FC<ExampleProps> = (props) => {
+  return (
+    <PromiseResolverComp
+      promise={sleep(props.milliseconds).then(() => props.value)}
+    >
+      <ConsumeSnapshot />
+    </PromiseResolverComp>
+  );
+};
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/Async/Promise Resolver',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const PromiseResolver: Story = {
+  args: {
+    value: 'Done!',
+    milliseconds: 2000,
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/__test__/PromiseBuilder.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/__test__/PromiseBuilder.test.tsx
@@ -1,0 +1,48 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import PromiseBuilder, { PromiseBuilderBuilderProps } from '../PromiseBuilder';
+import { AsyncSnapshot, AsyncState } from '../AsyncSnapshot';
+
+describe('Promise Builder Component', () => {
+  it('Resolves Successfully', async () => {
+    const resolutionStack: AsyncSnapshot<unknown>[] = [];
+
+    const Comp: React.FC<PromiseBuilderBuilderProps<unknown>> = (props) => {
+      const snapshot = props.snapshot;
+      resolutionStack.push(snapshot);
+
+      return <div data-testid="1" data-async-state={snapshot.asyncState} />;
+    };
+
+    render(<PromiseBuilder promise={Promise.resolve(1)} builder={Comp} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('1')).toHaveAttribute(
+        'data-async-state',
+        String(AsyncState.done)
+      );
+    });
+
+    expect(resolutionStack.length).equals(2);
+    {
+      // First state
+      const entry = resolutionStack[0];
+      expect(entry.asyncState).equals(AsyncState.waiting);
+      expect(entry.hasData).equals(false);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(undefined);
+      expect(entry.error).equals(undefined);
+    }
+    {
+      // second state
+      const entry = resolutionStack[1];
+      expect(entry.asyncState).equals(AsyncState.done);
+      expect(entry.hasData).equals(true);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(1);
+      expect(entry.error).equals(undefined);
+    }
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/__test__/PromiseResolver.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/__test__/PromiseResolver.test.tsx
@@ -1,0 +1,128 @@
+import '@testing-library/jest-dom';
+import { render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { AsyncSnapshot, AsyncState } from '../AsyncSnapshot';
+import { AsyncSnapshotContext } from '../AsyncSnapshotContext';
+import PromiseResolver from '../PromiseResolver';
+
+describe('Promise Resolver Component', () => {
+  it('Resolves Successfully', async () => {
+    const resolutionStack: AsyncSnapshot<unknown>[] = [];
+
+    const Comp: React.FC = (props) => {
+      const snapshot = React.useContext(AsyncSnapshotContext);
+      resolutionStack.push(snapshot);
+      return <div data-async-state={snapshot.asyncState} {...props} />;
+    };
+
+    const { rerender } = render(
+      <PromiseResolver promise={Promise.resolve(1)}>
+        <Comp data-testid="1" />
+      </PromiseResolver>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('1')).toHaveAttribute(
+        'data-async-state',
+        String(AsyncState.done)
+      );
+    });
+
+    expect(resolutionStack.length).equals(2);
+    {
+      // First state
+      const entry = resolutionStack[0];
+      expect(entry.asyncState).equals(AsyncState.waiting);
+      expect(entry.hasData).equals(false);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(undefined);
+      expect(entry.error).equals(undefined);
+    }
+    {
+      // second state
+      const entry = resolutionStack[1];
+      expect(entry.asyncState).equals(AsyncState.done);
+      expect(entry.hasData).equals(true);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(1);
+      expect(entry.error).equals(undefined);
+    }
+
+    rerender(
+      <PromiseResolver promise={Promise.resolve(2)}>
+        <Comp data-testid="1" />
+      </PromiseResolver>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('1')).toHaveAttribute(
+        'data-async-state',
+        String(AsyncState.done)
+      );
+    });
+
+    expect(resolutionStack.length).equals(4);
+    {
+      // third state
+      const entry = resolutionStack[2];
+      expect(entry.asyncState).equals(AsyncState.waiting);
+      expect(entry.hasData).equals(false);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(undefined);
+      expect(entry.error).equals(undefined);
+    }
+    {
+      // fourth state
+      const entry = resolutionStack[3];
+      expect(entry.asyncState).equals(AsyncState.done);
+      expect(entry.hasData).equals(true);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(2);
+      expect(entry.error).equals(undefined);
+    }
+  });
+
+  it('Rejects Successfully', async () => {
+    const resolutionStack: AsyncSnapshot<unknown>[] = [];
+
+    const Comp: React.FC = (props) => {
+      const snapshot = React.useContext(AsyncSnapshotContext);
+      resolutionStack.push(snapshot);
+      return <div data-async-state={snapshot.asyncState} {...props} />;
+    };
+
+    render(
+      <PromiseResolver promise={Promise.reject(1)}>
+        <Comp data-testid="1" />
+      </PromiseResolver>
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('1')).toHaveAttribute(
+        'data-async-state',
+        String(AsyncState.done)
+      );
+    });
+
+    expect(resolutionStack.length).equals(2);
+    {
+      // First state
+      const entry = resolutionStack[0];
+      expect(entry.asyncState).equals(AsyncState.waiting);
+      expect(entry.hasData).equals(false);
+      expect(entry.hasError).equals(false);
+      expect(entry.data).equals(undefined);
+      expect(entry.error).equals(undefined);
+    }
+    {
+      // second state
+      const entry = resolutionStack[1];
+      expect(entry.asyncState).equals(AsyncState.done);
+      expect(entry.hasData).equals(false);
+      expect(entry.hasError).equals(true);
+      expect(entry.data).equals(undefined);
+      expect(entry.error).equals(1);
+    }
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/data/async_data/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/data/async_data/index.ts
@@ -1,0 +1,5 @@
+export { AsyncSnapshot } from './AsyncSnapshot';
+export { AsyncSnapshotContext } from './AsyncSnapshotContext';
+export { default as PromiseBuilder } from './PromiseBuilder';
+export { default as PromiseResolver } from './PromiseResolver';
+export { default as ProvideAsyncStates } from './ProvideAsyncStates';

--- a/packages/espresso-block-explorer-components/src/components/data/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/data/index.ts
@@ -1,0 +1,1 @@
+export * from './async_data';

--- a/packages/espresso-block-explorer-components/src/components/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/index.ts
@@ -1,4 +1,5 @@
 export * from './contexts';
+export * from './data';
 export * from './text';
 export * from './typography';
 export * from './visual';


### PR DESCRIPTION
React components can only render in a synchronous manner, and this prevents them from easily using asynchronous code which can make it difficult to handle some async component cases.

As such we introduce the AsyncSnapShot that can allow us to create a SnapShot of an Asynchronous process in order for us to be able to render and resolve the async state by capturing it at a moment in time for components to reference.

Add DataContext, ErrorContext, and LoadingContext

As we find ourselves consuming the AsyncSnapshot we consider that we may not wish to inspect the entire AsyncSnapshot just to be able to reference certain parts of it.  For example, a loading indicator only really needs to know when data is loading, and is not actually concerned with the result of the actual data being loaded.

As such, we add different Contexts to represent the separate parts of the async process for easier reference.

Add PromiseResolver, ProvideAsyncStates and AsyncSnapshotContext

The PromiseResolver is a component that can take a Promise and automatically resolve it's lifecycle in order for those states to be available to descendant components.

This allows us to render states of the Async process with discrete AsyncSnapshots derived from the component.  It also allows our Component to update reactively as soon as there is a state change in the passed Promise.

Add PromiseBuilder component

The PromiseBuilder is a different way of utilizing the PromiseResolver component, for a way that might feel better to some users.  Ultimately it uses the same proven code path of the PromiseResolver.