### PR TITLE
Add TaggedBase64 type

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/text/TaggedBase64Text.tsx
+++ b/packages/espresso-block-explorer-components/src/components/text/TaggedBase64Text.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { TaggedBase64 } from '../../types/TaggedBase64';
+import { rawURLEncoding } from '../../types/base64';
+
+export interface TaggedBase64TextProps {
+  value: TaggedBase64;
+}
+
+/**
+ * TaggedBase64Text is a simple Text component that renders a TaggedBase64 value
+ * in it's own way.
+ */
+const TaggedBase64Text: React.FC<TaggedBase64TextProps> = (props) => {
+  const string = rawURLEncoding.encodeToString(props.value.data);
+
+  if (string.length <= 16) {
+    return string;
+  }
+
+  // Now this string is too long... So we will need to truncate it
+  // strategically.  Luckily this will be guaranteed to be an ascii
+  // string, so we should be able to truncate it in the middle independently.
+  return (
+    <span title={string}>
+      {string.substring(0, 8)}
+      ...
+      {string.substring(string.length - 8, string.length)}
+    </span>
+  );
+};
+
+export default TaggedBase64Text;

--- a/packages/espresso-block-explorer-components/src/components/text/__docs__/TaggedBase64Text.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/text/__docs__/TaggedBase64Text.stories.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import TaggedBase64Text from '../TaggedBase64Text';
+import { TaggedBase64 as TaggedBase64Object } from '../../../types/TaggedBase64';
+
+interface ExampleProps {
+  tag: string;
+  hex: number[];
+}
+const Example: React.FC<ExampleProps> = (props) => (
+  <TaggedBase64Text
+    value={new TaggedBase64Object(props.tag, new Uint8Array(props.hex).buffer)}
+  />
+);
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/Text/Tagged Base64',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const TaggedBase64: Story = {
+  args: {
+    tag: 'PUBKEY',
+    hex: [
+      0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc, 0xba, 0x98,
+      0x76, 0x54, 0x32, 0x10,
+    ],
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/text/__test__/NumberText.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/text/__test__/NumberText.test.tsx
@@ -15,7 +15,7 @@ describe('Number Text Component', () => {
             <NumberText number={1234567.89} />
           </ProvideDerivedNumberFormatters>
         </OverrideLocale>
-      </div>
+      </div>,
     );
     const text = screen.getByTestId('1');
     expect(text).toBeInTheDocument();

--- a/packages/espresso-block-explorer-components/src/components/text/__test__/TaggedBase64.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/text/__test__/TaggedBase64.test.tsx
@@ -1,0 +1,51 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { TaggedBase64 } from '../../../types/TaggedBase64';
+import TaggedBase64Text from '../TaggedBase64Text';
+
+describe('Tagged Base 64 Text Component', () => {
+  it('should format with full value', () => {});
+
+  it('should format as truncated value', () => {
+    render(
+      <div data-testid="1">
+        <TaggedBase64Text
+          value={
+            new TaggedBase64(
+              'TAG',
+              new Uint8Array([
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+              ]).buffer,
+            )
+          }
+        />
+      </div>,
+    );
+    const text = screen.getByTestId('1');
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveTextContent('ASNFZ4mrze8');
+  });
+
+  it('should format non-truncated', () => {
+    render(
+      <div data-testid="1">
+        <TaggedBase64Text
+          value={
+            new TaggedBase64(
+              'TAG',
+              new Uint8Array([
+                0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef, 0xfe, 0xdc,
+                0xba, 0x98, 0x76, 0x54, 0x32, 0x10,
+              ]).buffer,
+            )
+          }
+        />
+      </div>,
+    );
+    const text = screen.getByTestId('1');
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveTextContent('ASNFZ4mr...qYdlQyEA');
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/text/__test__/Text.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/text/__test__/Text.test.tsx
@@ -9,7 +9,7 @@ describe('Text Component', () => {
     render(
       <div data-testid="1">
         <Text text="Hello" />
-      </div>
+      </div>,
     );
     const text = screen.getByTestId('1');
     expect(text).toBeInTheDocument();

--- a/packages/espresso-block-explorer-components/src/components/text/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/text/index.ts
@@ -1,1 +1,2 @@
 export { default as Text } from './Text';
+export { default as TaggedBase64Text } from './TaggedBase64Text';

--- a/packages/espresso-block-explorer-components/src/index.ts
+++ b/packages/espresso-block-explorer-components/src/index.ts
@@ -1,1 +1,2 @@
 export * from './components';
+export * from './types';

--- a/packages/espresso-block-explorer-components/src/types/TaggedBase64.ts
+++ b/packages/espresso-block-explorer-components/src/types/TaggedBase64.ts
@@ -1,0 +1,53 @@
+import { rawURLEncoding } from './base64';
+
+/**
+ * TaggedBase64 is an implementation of the server side type of TaggedBase64.
+ * It separates the tag portion from the data portion so that they can be
+ * handled / assessed independently.
+ */
+export class TaggedBase64 {
+  public readonly tag: string;
+  public readonly data: ArrayBuffer;
+
+  constructor(tag: string, data: ArrayBuffer) {
+    this.tag = tag;
+    this.data = data;
+  }
+
+  public static fromString(input: string): TaggedBase64 {
+    const idx = input.indexOf('~');
+    if (idx < 0) {
+      throw new TypeError('unable to find ~ within string');
+    }
+
+    const tag = input.substring(0, idx);
+    const data = rawURLEncoding.decodeString(input.substring(idx + 1));
+    return new TaggedBase64(tag, data);
+  }
+
+  public static inflate(value: unknown): TaggedBase64 {
+    if (typeof value !== 'string') {
+      throw new TypeError(
+        `expected a string, instead received ${typeof value}`,
+      );
+    }
+
+    return TaggedBase64.fromString(value);
+  }
+
+  public toString(): string {
+    return `${this.tag}~${rawURLEncoding.encodeToString(this.data)}`;
+  }
+
+  public valueOf(): string {
+    return this.toString();
+  }
+
+  public toJSON() {
+    return this.toString();
+  }
+}
+
+export function isTaggedBase64(a: unknown): a is TaggedBase64 {
+  return a instanceof TaggedBase64;
+}

--- a/packages/espresso-block-explorer-components/src/types/__test__/TaggedBase64.test.ts
+++ b/packages/espresso-block-explorer-components/src/types/__test__/TaggedBase64.test.ts
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { TaggedBase64 } from '../TaggedBase64';
+import { rawURLEncoding } from '../base64';
+
+describe('TaggedBase64', () => {
+  describe('encoding', () => {
+    const raw =
+      'BLS_SIG~Wmt99l4trRZU91A6kBIIP748xkwE2eeDkmnAcwYNhQZZtwrwgqLYIEavovqw83HzRSEI2YvQvFeRz6f7I51GC30';
+    it('should split correctly', () => {
+      const taggedBase64 = TaggedBase64.fromString(raw);
+
+      expect(taggedBase64.tag).equals('BLS_SIG');
+      expect(rawURLEncoding.encodeToString(taggedBase64.data)).equals(
+        'Wmt99l4trRZU91A6kBIIP748xkwE2eeDkmnAcwYNhQZZtwrwgqLYIEavovqw83HzRSEI2YvQvFeRz6f7I51GC30',
+      );
+    });
+
+    const taggedBase64 = TaggedBase64.fromString(raw);
+    it('should return the correct value', () => {
+      expect(taggedBase64.valueOf()).equals(raw);
+    });
+
+    it('should have a string representation for JSON', () => {
+      expect(taggedBase64.toJSON()).equals(raw);
+    });
+
+    it('should encode as a JSON string', () => {
+      expect(JSON.stringify(taggedBase64)).equals(`"${raw}"`);
+    });
+
+    it('should revive into a TaggedBase64', () => {
+      expect(
+        TaggedBase64.inflate(JSON.parse(JSON.stringify(taggedBase64))),
+      ).satisfies((a) => a instanceof TaggedBase64);
+    });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/types/__test__/base64.test.ts
+++ b/packages/espresso-block-explorer-components/src/types/__test__/base64.test.ts
@@ -1,0 +1,174 @@
+import '@testing-library/jest-dom';
+import { describe, expect, it } from 'vitest';
+import { stdEncoding, rawURLEncoding } from '../base64';
+
+function* charCodes(str: string): Generator<number> {
+  const l = str.length;
+  for (let i = 0; i < l; i++) {
+    yield str.charCodeAt(i);
+  }
+}
+
+describe('base64', () => {
+  describe('Std Encoding', () => {
+    describe('RFC 3548 examples', () => {
+      it('should encode to expected value', () => {
+        const examples = new Map<ArrayBuffer, string>([
+          [
+            new Uint8Array([0x14, 0xfb, 0x9c, 0x03, 0xd9, 0x7e]).buffer,
+            'FPucA9l+',
+          ],
+          [new Uint8Array([0x14, 0xfb, 0x9c, 0x03, 0xd9]).buffer, 'FPucA9k='],
+          [new Uint8Array([0x14, 0xfb, 0x9c, 0x003]).buffer, 'FPucAw=='],
+        ]);
+
+        for (const [input, want] of examples.entries()) {
+          expect(stdEncoding.encodeToString(input)).equals(want);
+        }
+      });
+    });
+
+    describe('RFC 4648 examples', () => {
+      it('should encode to expected value', () => {
+        const examples = new Map<ArrayBuffer, string>([
+          [new Uint8Array(charCodes('')).buffer, ''],
+          [new Uint8Array(charCodes('f')).buffer, 'Zg=='],
+          [new Uint8Array(charCodes('fo')).buffer, 'Zm8='],
+          [new Uint8Array(charCodes('foo')).buffer, 'Zm9v'],
+          [new Uint8Array(charCodes('foob')).buffer, 'Zm9vYg=='],
+          [new Uint8Array(charCodes('fooba')).buffer, 'Zm9vYmE='],
+          [new Uint8Array(charCodes('foobar')).buffer, 'Zm9vYmFy'],
+        ]);
+
+        for (const [input, want] of examples.entries()) {
+          expect(stdEncoding.encodeToString(input)).equals(want);
+        }
+      });
+    });
+
+    describe('Wikipedia Examples', () => {
+      it('should encode to expected value', () => {
+        const examples = new Map<ArrayBuffer, string>([
+          [new Uint8Array(charCodes('sure.')).buffer, 'c3VyZS4='],
+          [new Uint8Array(charCodes('sure')).buffer, 'c3VyZQ=='],
+          [new Uint8Array(charCodes('sur')).buffer, 'c3Vy'],
+          [new Uint8Array(charCodes('su')).buffer, 'c3U='],
+          [new Uint8Array(charCodes('leasure.')).buffer, 'bGVhc3VyZS4='],
+          [new Uint8Array(charCodes('easure.')).buffer, 'ZWFzdXJlLg=='],
+          [new Uint8Array(charCodes('asure.')).buffer, 'YXN1cmUu'],
+          [new Uint8Array(charCodes('sure.')).buffer, 'c3VyZS4='],
+        ]);
+
+        for (const [input, want] of examples.entries()) {
+          expect(stdEncoding.encodeToString(input)).equals(want);
+        }
+      });
+    });
+
+    describe('Decoding Corruption', () => {
+      it('should not be corrupted', () => {
+        const examples = ['', '\n', 'AAA=', 'AAAA\n', 'AA==', 'AAA=', 'AAAA'];
+
+        for (const example of examples) {
+          expect(() =>
+            stdEncoding.decode(new Uint8Array(charCodes(example)).buffer),
+          ).not.throws();
+        }
+      });
+
+      it('should be corrupted', () => {
+        const examples = [
+          '!!!!',
+          '====',
+          'x===',
+          '-AAA',
+          'A=AA',
+          'AA=A',
+          'AAA=AAAA',
+          'AAAAA',
+          'AAAAAA',
+          'A=',
+          'A==',
+          'AA=',
+          'AAAAA=',
+          'YWJjZA=====',
+          'A!\n',
+          'A=\n',
+        ];
+
+        for (const example of examples) {
+          expect(() =>
+            stdEncoding.decode(new Uint8Array(charCodes(example))),
+          ).throws();
+        }
+      });
+    });
+
+    describe('With New Lines', () => {
+      it('should decode to "sure"', () => {
+        const examples = [
+          'c3VyZQ==',
+          'c3VyZQ==\r',
+          'c3VyZQ==\n',
+          'c3VyZQ==\r\n',
+          'c3VyZ\r\nQ==',
+          'c3V\ryZ\nQ==',
+          'c3V\nyZ\rQ==',
+          'c3VyZ\nQ==',
+          'c3VyZQ\n==',
+          'c3VyZQ=\n=',
+          'c3VyZQ=\r\n\r\n=',
+        ];
+        const textDecoder = new TextDecoder();
+
+        for (const example of examples) {
+          const buffer = stdEncoding.decode(
+            new Uint8Array(charCodes(example)).buffer,
+          );
+          const have = textDecoder.decode(buffer);
+          expect(have).equals('sure');
+        }
+      });
+    });
+  });
+
+  describe('encoding', () => {
+    it('should re-encode to what was encoded when a multiple of 4', () => {
+      const raw = 'deadbeef';
+      const decoded = rawURLEncoding.decodeString(raw);
+      expect(Array.from(new Uint8Array(decoded))).deep.equals([
+        117, 230, 157, 109, 231, 159,
+      ]);
+      expect(decoded.byteLength).equals(6);
+      const encoded = rawURLEncoding.encodeToString(decoded);
+
+      expect(encoded).equals(raw);
+    });
+
+    it('should re-encode with a longer example', () => {
+      const raw =
+        'Wmt99l4trRZU91A6kBIIP748xkwE2eeDkmnAcwYNhQZZtwrwgqLYIEavovqw83HzRSEI2YvQvFeRz6f7I51GC30';
+      const decoded = rawURLEncoding.decodeString(raw);
+      expect(Array.from(new Uint8Array(decoded))).deep.equals([
+        90, 107, 125, 246, 94, 45, 173, 22, 84, 247, 80, 58, 144, 18, 8, 63,
+        190, 60, 198, 76, 4, 217, 231, 131, 146, 105, 192, 115, 6, 13, 133, 6,
+        89, 183, 10, 240, 130, 162, 216, 32, 70, 175, 162, 250, 176, 243, 113,
+        243, 69, 33, 8, 217, 139, 208, 188, 87, 145, 207, 167, 251, 35, 157, 70,
+        11, 125,
+      ]);
+      expect(decoded.byteLength).equals(65);
+      const encoded = rawURLEncoding.encodeToString(decoded);
+
+      expect(encoded).equals(raw);
+    });
+
+    // it('should re-encode to what was encoded when a multiple of 3', () => {
+    //   const raw = 'deadbe';
+    //   const decoded = rawURLEncoding.decodeString(raw);
+    //   expect(decoded.byteLength).equals(5);
+    //   const encoded = rawURLEncoding.encodeToString(decoded);
+
+    //   expect(encoded).equals(raw);
+    // });
+  });
+});

--- a/packages/espresso-block-explorer-components/src/types/base64.ts
+++ b/packages/espresso-block-explorer-components/src/types/base64.ts
@@ -1,0 +1,300 @@
+const textEncoder = new TextEncoder();
+export function convertStringToArrayBuffer(s: string): Uint8Array {
+  return textEncoder.encode(s);
+}
+
+const textDecoder = new TextDecoder();
+export function convertArrayBufferToString(ab: ArrayBuffer): string {
+  return textDecoder.decode(ab);
+}
+
+export function* charCodesFromString(s: string) {
+  const data = convertStringToArrayBuffer(s);
+  yield* data;
+}
+
+function* fill256Array() {
+  for (let i = 0; i < 256; i++) {
+    yield 0xff;
+  }
+}
+
+export const noPadding = -1;
+export const stdPadding = '='.charCodeAt(0);
+
+/**
+ * Encoding represents a Base64 Encoding type. This class allows for the
+ * creation of new Base64 Encodings with different alphabets of non standard
+ * ordering.
+ */
+export class Encoding {
+  private encodeMap: number[];
+  private decodeMap: number[];
+  private padChar: number;
+  private strict: boolean;
+
+  constructor(
+    encodeMap: number[],
+    decodeMap: number[],
+    padChar: number = stdPadding,
+    strict: boolean = false,
+  ) {
+    this.encodeMap = encodeMap;
+    this.decodeMap = decodeMap;
+    this.padChar = padChar;
+    this.strict = strict;
+  }
+
+  static withAlphabet(alphabet: string): Encoding {
+    const l = alphabet.length;
+    if (l !== 64) {
+      throw new TypeError(`alphabet needs to be 64 chars, got ${l}`);
+    }
+
+    const encodeMap = Array.from(charCodesFromString(alphabet));
+    const decodeMap = Array.from(fill256Array());
+    for (let i = 0; i < l; i++) {
+      decodeMap[encodeMap[i]] = i;
+    }
+
+    return new Encoding(encodeMap, decodeMap);
+  }
+
+  withPadding(padChar: number): Encoding {
+    return new Encoding(this.encodeMap, this.decodeMap, padChar, this.strict);
+  }
+
+  public encode(input: ArrayBuffer): ArrayBuffer {
+    if (input.byteLength === 0) {
+      return new ArrayBuffer(0);
+    }
+
+    let di = 0,
+      si = 0;
+    const n = Math.floor(input.byteLength / 3) * 3;
+    const nextSize = Math.ceil(input.byteLength / 3) * 4;
+    const result = new ArrayBuffer(nextSize);
+    const src = new DataView(input);
+    const dst = new DataView(result);
+    while (si < n) {
+      // Convert 3x 8bit source bytes into 4 bytes
+      const val =
+        (src.getUint8(si + 0) << 16) |
+        (src.getUint8(si + 1) << 8) |
+        src.getUint8(si + 2);
+
+      dst.setUint8(di + 0, this.encodeMap[(val >> 18) & 0x3f]);
+      dst.setUint8(di + 1, this.encodeMap[(val >> 12) & 0x3f]);
+      dst.setUint8(di + 2, this.encodeMap[(val >> 6) & 0x3f]);
+      dst.setUint8(di + 3, this.encodeMap[val & 0x3f]);
+
+      si += 3;
+      di += 4;
+    }
+
+    const remain = input.byteLength - si;
+    if (remain === 0) {
+      return result;
+    }
+
+    // Add the remaining small block
+    let val = src.getUint8(si + 0) << 16;
+    if (remain === 2) {
+      val |= src.getUint8(si + 1) << 8;
+    }
+
+    dst.setUint8(di + 0, this.encodeMap[(val >> 18) & 0x3f]);
+    dst.setUint8(di + 1, this.encodeMap[(val >> 12) & 0x3f]);
+
+    switch (remain) {
+      case 2:
+        dst.setUint8(di + 2, this.encodeMap[(val >> 6) & 0x3f]);
+        if (this.padChar !== noPadding) {
+          dst.setUint8(di + 3, this.padChar);
+          return result.slice(0, di + 4);
+        }
+        return result.slice(0, di + 3);
+      case 1:
+        if (this.padChar !== noPadding) {
+          dst.setUint8(di + 2, this.padChar);
+          dst.setUint8(di + 3, this.padChar);
+          return result.slice(0, di + 4);
+        }
+
+        break;
+    }
+
+    return result.slice(0, di + 2);
+  }
+
+  public decode(input: ArrayBuffer): ArrayBuffer {
+    const l = input.byteLength;
+    if (l === 0) {
+      return new ArrayBuffer(0);
+    }
+
+    const src = new DataView(input);
+    const result = new ArrayBuffer(Math.floor((l / 4) * 3));
+    const dst = new DataView(result);
+    const temp = new ArrayBuffer(4);
+    const dBuf = new DataView(temp);
+    let n = 0;
+    let si = 0;
+    let di = 0;
+    let end = false;
+
+    while (si < l && !end) {
+      // Read 4 bytes.
+      // accounting for newline, carriage return, and padding bytes.
+      let dinc = 3,
+        dlen = 4;
+
+      for (let j = 0; j < 4; j++) {
+        if (si === l) {
+          // This is potentially an error
+          if (j === 0) {
+            // n, false, nil
+            return result;
+          }
+
+          if (j === 1 || this.padChar !== noPadding) {
+            // n, false, error
+            throw new TypeError(`corrupted input error at ${si - j}`);
+          }
+
+          dinc = j - 1;
+          dlen = j;
+          end = true;
+          break;
+        }
+
+        const inV = src.getUint8(si);
+        si++;
+
+        const out = this.decodeMap[inV];
+        if (out !== 0xff) {
+          dBuf.setUint8(j, out);
+          continue;
+        }
+
+        if (inV === 0x0a || inV === 0x0d) {
+          j--;
+          continue;
+        }
+
+        if (inV === this.padChar) {
+          // We've reached the end and there's padding
+          switch (j) {
+            case 0:
+            /* falls through */
+            case 1:
+              // incorrect padding
+              // n, false, error
+              throw new Error('Incorrect padding');
+
+            case 2:
+              // two paddings are expected, the first padding is already
+              // consumed.
+              // skip new lines.
+              while (
+                si < l &&
+                (src.getUint8(si) === 0x0a || src.getUint8(si) === 0x0d)
+              ) {
+                si++;
+              }
+              if (si === l) {
+                // not enough padding
+                throw new TypeError(`corrupt input error at ${l}`);
+              }
+
+              if (src.getUint8(si) !== this.padChar) {
+                // incorrect padding
+                throw new Error(`corrupt input error at ${si - 1}`);
+              }
+
+              si++;
+          }
+
+          // Skip over newlines
+          while (
+            si < l &&
+            (src.getUint8(si) === 0x0a || src.getUint8(si) === 0x0d)
+          ) {
+            si++;
+          }
+
+          if (si < l) {
+            // trailing garbage
+            throw new TypeError(`corrupt input error at ${si}`);
+          }
+          dinc = 3;
+          dlen = j;
+          end = true;
+          break;
+        }
+
+        throw new TypeError(`corrupt input error ${si - 1}`);
+      }
+
+      // Convert 4x 6bit source bytes into 3 bytes
+      const val =
+        (dBuf.getUint8(0) << 18) |
+        (dBuf.getUint8(1) << 12) |
+        (dBuf.getUint8(2) << 6) |
+        dBuf.getUint8(3);
+
+      dBuf.setUint8(2, (val >> 0) & 0xff);
+      dBuf.setUint8(1, (val >> 8) & 0xff);
+      dBuf.setUint8(0, (val >> 16) & 0xff);
+
+      switch (dlen) {
+        case 4:
+          dst.setUint8(di + 2, dBuf.getUint8(2));
+          dBuf.setUint8(2, 0);
+        /* falls through */
+
+        case 3:
+          dst.setUint8(di + 1, dBuf.getUint8(1));
+          if (this.strict && dBuf.getUint8(2) !== 0) {
+            throw new TypeError(`corrupt input error at ${si - 1}`);
+          }
+          dBuf.setUint8(1, 0);
+        /* falls through */
+
+        case 2:
+          dst.setUint8(di + 0, dBuf.getUint8(0));
+          if (
+            this.strict &&
+            (dBuf.getUint8(1) !== 0 || dBuf.getUint8(2) !== 0)
+          ) {
+            throw new TypeError(`corrupt input error at ${si - 2}`);
+          }
+      }
+
+      di += dinc;
+      n += dlen - 1;
+    }
+
+    return result.slice(0, n);
+  }
+
+  public decodeString(s: string) {
+    return this.decode(convertStringToArrayBuffer(s).buffer);
+  }
+
+  public encodeToString(src: ArrayBuffer) {
+    return convertArrayBufferToString(this.encode(src));
+  }
+}
+
+export const stdEncoding = Encoding.withAlphabet(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/',
+);
+
+export const rawStdEncoding = stdEncoding.withPadding(noPadding);
+
+export const urlEncoding = Encoding.withAlphabet(
+  'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_',
+);
+
+export const rawURLEncoding = urlEncoding.withPadding(noPadding);

--- a/packages/espresso-block-explorer-components/src/types/index.ts
+++ b/packages/espresso-block-explorer-components/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './TaggedBase64';


### PR DESCRIPTION
In order to better facilitate the data that will need to be translated between the server and the client it is good to have some data types that can readily represent the data we will find online.

This commit introduces the TaggedBase64 type.  This is an implementation of the TaggedBase64 data type in javascript so we can ensure that our data members match and ultimately represent the same values on the server or locally on the client.

Add TaggedBase64Text Component

We find ourselves with the need to display the Tagged Base 64 value in a Textual way.  This component is an initial attempt at doing this.