### PR TITLE
Add Icon Button Components

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/IconAnchorButton.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/IconAnchorButton.tsx
@@ -1,0 +1,12 @@
+import { addClassToClassName } from '../../../higher_order';
+import AnchorButton, { AnchorButtonProps } from '../anchor_button/AnchorButton';
+
+const IconAnchorButton: React.FC<AnchorButtonProps> = (props) => (
+  <AnchorButton
+    {...props}
+    // eslint-disable-next-line react/prop-types
+    className={addClassToClassName(props.className, 'icon')}
+  />
+);
+
+export default IconAnchorButton;

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/__docs__/IconAnchorButton.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/__docs__/IconAnchorButton.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ArrowLeft from '../../../../visual/icons/ArrowLeft';
+import ArrowRight from '../../../../visual/icons/ArrowRight';
+import CheckCircle from '../../../../visual/icons/CheckCircle';
+import ChevronDown from '../../../../visual/icons/ChevronDown';
+import ChevronUp from '../../../../visual/icons/ChevronUp';
+import DiscordIcon from '../../../../visual/icons/DiscordIcon';
+import InfoCircle from '../../../../visual/icons/InfoCircle';
+import MediumIcon from '../../../../visual/icons/MediumIcon';
+import Menu from '../../../../visual/icons/Menu';
+import SearchGlass from '../../../../visual/icons/SearchGlass';
+import TwitterIcon from '../../../../visual/icons/TwitterIcon';
+import IconAnchorButtonComp from '../IconAnchorButton';
+
+interface ExampleProps {
+  href: string;
+  title: string;
+  disabled: boolean;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+const Example: React.FC<ExampleProps> = ({
+  disabled,
+  href,
+  children,
+  ...props
+}) => (
+  <IconAnchorButtonComp
+    disabled={disabled}
+    href={href}
+    target="_blank"
+    {...props}
+  >
+    {children}
+  </IconAnchorButtonComp>
+);
+
+const Children = {
+  'Arrow Left': React.createElement(ArrowLeft),
+  'Arrow Right': React.createElement(ArrowRight),
+  'Check Circle': React.createElement(CheckCircle),
+  'Chevron Down': React.createElement(ChevronDown),
+  'Chevron Up': React.createElement(ChevronUp),
+  'Discord Icon': React.createElement(DiscordIcon),
+  'Info Circle': React.createElement(InfoCircle),
+  'Medium Icon': React.createElement(MediumIcon),
+  Menu: React.createElement(Menu),
+  'Search Glass': React.createElement(SearchGlass),
+  'Twitter Icon': React.createElement(TwitterIcon),
+};
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/HID/Buttons/Icon Anchor Button',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const IconAnchorButton: Story = {
+  args: {
+    title: 'Example',
+    href: 'https://example.com/',
+    disabled: false,
+    children: React.createElement(ArrowLeft),
+  },
+
+  argTypes: {
+    children: {
+      options: Object.keys(Children),
+      mapping: Children,
+      control: {
+        type: 'select',
+        labels: Object.keys(Children),
+      },
+    },
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/__test__/IconButton.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/__test__/IconButton.test.tsx
@@ -1,0 +1,31 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/IconAnchorButton.stories';
+
+const { IconAnchorButton } = composeStories(stories);
+
+describe('Icon Button component', () => {
+  it('should render the Icon Button normally', async () => {
+    render(<IconAnchorButton data-testid="1" href="https://example.com/" />);
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/');
+
+    await userEvent.click(link);
+  });
+
+  it('should render Icon Button disabled', async () => {
+    render(
+      <IconAnchorButton data-testid="1" disabled href="https://example.com/" />,
+    );
+    const link = screen.getByTestId('1');
+    expect(link).toBeInTheDocument();
+    expect(link).not.toHaveAttribute('href');
+
+    await userEvent.click(link);
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_anchor_button/index.ts
@@ -1,0 +1,1 @@
+export { default as IconAnchorButton } from './IconAnchorButton';

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/IconButton.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/IconButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { addClassToClassName } from '../../../higher_order';
+import Button, { ButtonProps } from '../button/Button';
+
+/**
+ * IconButton represents a Button with a simple icon within it.  It is styled
+ * for a simple 24px x 24px icon to be contained within it, and as such it has
+ * styles that account for this.
+ */
+const IconButton: React.FC<ButtonProps> = ({ className, ...props }) => (
+  <Button
+    className={addClassToClassName(className, 'icon type--ui--button')}
+    {...props}
+  />
+);
+
+export default IconButton;

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/__docs__/IconButton.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/__docs__/IconButton.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import ArrowLeft from '../../../../visual/icons/ArrowLeft';
+import ArrowRight from '../../../../visual/icons/ArrowRight';
+import CheckCircle from '../../../../visual/icons/CheckCircle';
+import ChevronDown from '../../../../visual/icons/ChevronDown';
+import ChevronUp from '../../../../visual/icons/ChevronUp';
+import DiscordIcon from '../../../../visual/icons/DiscordIcon';
+import InfoCircle from '../../../../visual/icons/InfoCircle';
+import MediumIcon from '../../../../visual/icons/MediumIcon';
+import Menu from '../../../../visual/icons/Menu';
+import SearchGlass from '../../../../visual/icons/SearchGlass';
+import TwitterIcon from '../../../../visual/icons/TwitterIcon';
+import IconButtonComp from '../IconButton';
+
+interface ExampleProps {
+  title: string;
+  disabled: boolean;
+  onClick?: () => void;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+const Example: React.FC<ExampleProps> = ({
+  title,
+  disabled,
+  children,
+  ...props
+}) => (
+  <IconButtonComp title={title} disabled={disabled} {...props}>
+    {children}
+  </IconButtonComp>
+);
+
+const Children = {
+  'Arrow Left': React.createElement(ArrowLeft),
+  'Arrow Right': React.createElement(ArrowRight),
+  'Check Circle': React.createElement(CheckCircle),
+  'Chevron Down': React.createElement(ChevronDown),
+  'Chevron Up': React.createElement(ChevronUp),
+  'Discord Icon': React.createElement(DiscordIcon),
+  'Info Circle': React.createElement(InfoCircle),
+  'Medium Icon': React.createElement(MediumIcon),
+  Menu: React.createElement(Menu),
+  'Search Glass': React.createElement(SearchGlass),
+  'Twitter Icon': React.createElement(TwitterIcon),
+};
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/HID/buttons/Icon Button',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const IconButton: Story = {
+  args: {
+    title: 'Back',
+    disabled: false,
+    children: React.createElement(ArrowLeft),
+  },
+
+  argTypes: {
+    children: {
+      options: Object.keys(Children),
+      mapping: Children,
+      control: {
+        type: 'select',
+        labels: Object.keys(Children),
+      },
+    },
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/__test__/IconButton.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/__test__/IconButton.test.tsx
@@ -1,0 +1,35 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/IconButton.stories';
+
+const { IconButton } = composeStories(stories);
+
+describe('Icon Button component', () => {
+  it('should render the Icon Button normally', async () => {
+    let a = 0;
+    render(<IconButton data-testid="1" onClick={() => (a = a + 1)} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+    expect(a).equals(0);
+
+    await userEvent.click(button);
+    expect(a).equals(1);
+  });
+
+  it('should render Icon Button disabled', async () => {
+    let a = 0;
+    render(<IconButton data-testid="1" disabled onClick={() => (a = a + 1)} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(a).equals(0);
+
+    await userEvent.click(button);
+    expect(a).equals(0, 'tapping on a disabled button should have no result');
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/icon_button/index.ts
@@ -1,0 +1,1 @@
+export { default as IconButton } from './IconButton';

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/index.ts
@@ -1,2 +1,4 @@
 export * from './anchor_button';
 export * from './button';
+export * from './icon_anchor_button';
+export * from './icon_button';


### PR DESCRIPTION
This commit adds the components for an IconButton and an
IconAnchorButton.  These are just regular buttons, but they are
meant to house an icon. As such, they have styles that provides
the spacing needed for the IconButton to match the style guide.

Closes #14