### PR TITLE
Add TabeledLabeledValue component

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/index.ts
@@ -1,6 +1,7 @@
 export * from './contexts';
 export * from './data';
 export * from './hid';
+export * from './layout';
 export * from './links';
 export * from './text';
 export * from './typography';

--- a/packages/espresso-block-explorer-components/src/components/layout/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/layout/index.ts
@@ -1,0 +1,1 @@
+export * from './table_labeled_value';

--- a/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/TabledLabeledValue.tsx
+++ b/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/TabledLabeledValue.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { addClassToClassName } from '../../higher_order';
+import { WithUiSmall, WithUiText600 } from '../../typography/typography';
+import './tabled_labeled_value.css';
+
+const LabelText600 = WithUiText600('label');
+const DivTextSmall = WithUiSmall('div');
+
+interface LabelProps {
+  className?: string;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * Label represents the Label portion of the TabledLabeledValue component.
+ * It ensures that text rendered within the label has the correct typography.
+ */
+const Label: React.FC<LabelProps> = (props) => (
+  <LabelText600>{props.children}</LabelText600>
+);
+
+interface ValueProps {
+  className?: string;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * Value represents the Value portion of the TabledLabeledValue component.
+ * It ensures that text rendered within the value has the correct typography.
+ */
+const Value: React.FC<ValueProps> = (props) => (
+  <DivTextSmall className="value">{props.children}</DivTextSmall>
+);
+
+export interface TableLabeledValueProps {
+  className?: string;
+  children: [React.ReactNode, React.ReactNode];
+}
+
+/**
+ * TabledLabeledValue is a component that is meant to display a label and
+ * value pair of components, and lay them out depending on the screen size
+ * of the device in question.
+ *
+ * If on a sufficiently large device, they should appear side by side as
+ * if in a full sized table element. Otherwise, they should appear as
+ * a single element of sufficient size.
+ */
+const TabledLabeledValue: React.FC<TableLabeledValueProps> = ({
+  className,
+  children,
+  ...props
+}) => (
+  <div
+    {...props}
+    className={addClassToClassName(className, 'tabled-labeled-value')}
+  >
+    <Label className="label" key={0}>
+      {children[0]}
+    </Label>
+    <Value className="value" key={1}>
+      {children[1]}
+    </Value>
+  </div>
+);
+
+export default TabledLabeledValue;

--- a/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/__docs__/TabledLabeledValue.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/__docs__/TabledLabeledValue.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Text from '../../../text/Text';
+import TabledLabeledValueComp from '../TabledLabeledValue';
+
+interface ExampleProps {
+  label: string;
+  value: string;
+}
+
+const Example: React.FC<ExampleProps> = ({ label, value, ...props }) => (
+  <TabledLabeledValueComp {...props}>
+    <Text text={label} />
+    <Text text={value} />
+  </TabledLabeledValueComp>
+);
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/Layout/Tabled Labeled Value',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const TabledLabeledValue: Story = {
+  args: {
+    label: 'Label',
+    value: '100',
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/__test__/TabledLabeledValue.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/__test__/TabledLabeledValue.test.tsx
@@ -1,0 +1,17 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/TabledLabeledValue.stories';
+
+const { TabledLabeledValue } = composeStories(stories);
+
+describe('Text Component', () => {
+  it('Should display the text that has been passed to it', () => {
+    render(<TabledLabeledValue data-testid="1" label="hello" value="world" />);
+    const text = screen.getByTestId('1');
+    expect(text).toBeInTheDocument();
+    expect(text).toHaveTextContent('helloworld');
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/index.ts
@@ -1,0 +1,2 @@
+export * from './TabledLabeledValue';
+export { default as TabledLabeledValue } from './TabledLabeledValue';

--- a/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/tabled_labeled_value.css
+++ b/packages/espresso-block-explorer-components/src/components/layout/table_labeled_value/tabled_labeled_value.css
@@ -1,0 +1,36 @@
+.tabled-labeled-value {
+  display: grid;
+  border-bottom: 1px solid var(--color--slate-100);
+}
+
+.tabled-labeled-value:nth-last-child(1) {
+  border-bottom: 0;
+}
+
+.tabled-labeled-value > label {
+  grid-area: label;
+}
+
+.tabled-labeled-value > div.value {
+  box-sizing: border-box;
+  grid-area: value;
+}
+
+/* Mobile */
+.tabled-labeled-value {
+  padding: 11px 0;
+  grid-template-columns: auto;
+  grid-template-rows: auto auto;
+  grid-template-areas: 'label' 'value';
+  gap: 8px;
+}
+
+/* Medium */
+@media screen and (min-width: 768px) {
+  .tabled-labeled-value {
+    grid-template-columns: 1fr 1fr;
+    gap: 20px;
+    grid-template-rows: auto;
+    grid-template-areas: 'label value';
+  }
+}


### PR DESCRIPTION
The design requires a layout that is seemingly tabular
when the screen is large enough, but collapses into a
single element when the screen is too small to
reasonably accommodate the tabular layout.

This commit adds this component for general use.

Closes #16