### PR TITLE
Add Hex Dump Component

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/index.ts
@@ -3,6 +3,7 @@ export * from './data';
 export * from './hid';
 export * from './layout';
 export * from './links';
+export * from './page_sections';
 export * from './text';
 export * from './typography';
 export * from './visual';

--- a/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/HexDump.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/HexDump.tsx
@@ -1,0 +1,107 @@
+import React from 'react';
+import { mapIterable, yieldAll } from '../../../types/functional';
+import { addClassToClassName } from '../../higher_order';
+import Text from '../../text/Text';
+import './hex_dump.css';
+
+export interface HexDumpProps {
+  className?: string;
+  value: ArrayBuffer;
+}
+
+/**
+ * hexEncodeOffset is a function that will encode the current binary offset
+ * of the ArrayBuffer with 6 hex digits of precision.
+ */
+function hexEncodeOffset(offset: number): string {
+  return Number(offset).toString(16).padStart(6, '0');
+}
+
+/**
+ * hexEncodeByte is a function that will encode a single given byte with
+ * 2 hex digits of precision.
+ */
+function hexEncodeByte(byte: number): string {
+  return Number(byte).toString(16).padStart(2, '0');
+}
+
+/**
+ * iterateWithStart is a function that pretends to be an iterator that
+ * adds another iterator to the start. It emulates behavior similarly to the
+ * cons function in Lisp / Scheme.
+ *
+ * @todo consider adding this to the functional file where it would likely
+ *       be better served, and could be reused.
+ */
+function* iterateWithStart<T>(start: T, it: Iterator<T>) {
+  yield start;
+  yield* yieldAll(it);
+}
+
+const bytesPerLine = 16;
+
+/**
+ * generateHexDumpLineFormat outputs a sequence of string elements for an
+ * individual line of the hexdump format.
+ */
+function* generateHexDumpLineFormat(offset: number, it: Iterator<string>) {
+  yield hexEncodeOffset(offset);
+  yield '  ';
+  for (let l = 0; l < bytesPerLine; l++) {
+    const next = it.next();
+    if (next.done) {
+      return;
+    }
+
+    if ((l & 0x01) === 0 && l !== 0) {
+      yield ' ';
+    }
+
+    yield next.value;
+  }
+}
+
+/**
+ * generateHexDumpLinesFormat takes an iterator of strings, which is assumed
+ * to be bytes formatted as hex.
+ */
+function* generateHexDumpLinesFormat(it: Iterator<string>) {
+  let offset = 0;
+
+  for (let next = it.next(); !next.done; next = it.next()) {
+    const line = Array.from(
+      generateHexDumpLineFormat(offset, iterateWithStart(next.value, it)),
+    ).join('');
+    offset += bytesPerLine;
+
+    yield line;
+  }
+}
+
+/**
+ * buildHexDumpString will output the given ArrayBuffer as a hexdump formatted
+ * string.
+ */
+function buildHexDumpString(value: ArrayBuffer): string {
+  const data = new Uint8Array(value);
+
+  const it = mapIterable(data, hexEncodeByte);
+  return Array.from(generateHexDumpLinesFormat(it)).join('\n');
+}
+
+/**
+ * HexDump is a component that will display the data content of an
+ * ArrayBuffer represented as hexadecimal.  It's format emulates
+ * the hexdump binary for alignment, formatting and display.
+ */
+const HexDump: React.FC<HexDumpProps> = ({ value, className, ...props }) => {
+  return (
+    <>
+      <pre {...props} className={addClassToClassName(className, 'hex-dump')}>
+        <Text text={buildHexDumpString(value)} />
+      </pre>
+    </>
+  );
+};
+
+export default HexDump;

--- a/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/__docs__/HexDump.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/__docs__/HexDump.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import HexDumpComp from '../HexDump';
+
+interface ExampleProps {
+  numBytes: number;
+}
+
+const Example: React.FC<ExampleProps> = (props) => {
+  const numBytes = Math.min(props.numBytes, 409600);
+  const array = new Uint8Array(numBytes);
+
+  for (let i = 0, l = array.byteLength; i < l; i++) {
+    array[i] = Math.floor(Math.random() * 256);
+  }
+
+  return <HexDumpComp value={array.buffer} />;
+};
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/Page Section/Hex Dump',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const HexDump: Story = {
+  args: {
+    numBytes: 1024,
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/__test__/HexDump.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/__test__/HexDump.test.tsx
@@ -1,0 +1,44 @@
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import HexDump from '../HexDump';
+
+describe('Hex Dump Component', () => {
+  it('displays the bytes correctly', async () => {
+    const { rerender } = render(
+      <HexDump
+        data-testid="1"
+        value={new Uint8Array([0xab, 0xbc, 0xcd, 0xde])}
+      />,
+    );
+
+    {
+      const hexDump = screen.getByTestId('1');
+      expect(hexDump).toBeInTheDocument();
+      expect(hexDump.tagName).equals('PRE');
+      expect(hexDump).toHaveTextContent('000000 abbc cdde');
+    }
+
+    rerender(
+      <HexDump
+        data-testid="1"
+        value={
+          new Uint8Array([
+            0xab, 0xbc, 0xcd, 0xde, 0xef, 0xf0, 0x01, 0x12, 0x23, 0x34, 0x45,
+            0x56, 0x67, 0x78, 0x89, 0x9a, 0xab, 0xbc, 0xcd, 0xde, 0xef, 0xf0,
+          ])
+        }
+      />,
+    );
+
+    {
+      const hexDump = screen.getByTestId('1');
+      expect(hexDump).toBeInTheDocument();
+      expect(hexDump.tagName).equals('PRE');
+      expect(hexDump).toHaveTextContent(
+        '000000 abbc cdde eff0 0112 2334 4556 6778 899a 000010 abbc cdde eff0',
+      );
+    }
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/hex_dump.css
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/hex_dump.css
@@ -1,0 +1,10 @@
+.hex-dump {
+  background-color: var(--color--slate-100);
+  border: 1px solid var(--color--slate-300);
+  border-radius: 8px;
+  max-height: 303px;
+  overflow-y: auto;
+  padding: 16px;
+  margin: 0;
+  box-sizing: border-box;
+}

--- a/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/hex_dump/index.ts
@@ -1,0 +1,1 @@
+export { default as HexDump } from './HexDump';

--- a/packages/espresso-block-explorer-components/src/components/page_sections/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/index.ts
@@ -1,0 +1,1 @@
+export * from './hex_dump';


### PR DESCRIPTION
The design calls for a display of the data encoded as a hex
string in a box for easy consumption.  It's format is quite
odd, and not something I truly understand, but it seems to
me that the hexdump format would more-or-less meet the
requirements as outlined.

This commit adds the HexDump component to allow for the
hex data to be viewed in a scrollable format.

Closes #42