### PR TITLE
Add Labeled Button Components

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/index.ts
@@ -2,3 +2,5 @@ export * from './anchor_button';
 export * from './button';
 export * from './icon_anchor_button';
 export * from './icon_button';
+export * from './labeled_anchor_button';
+export * from './labeled_button';

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/LabeledAnchorButton.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/LabeledAnchorButton.tsx
@@ -1,0 +1,17 @@
+import { addClassToClassName } from '../../../higher_order';
+import AnchorButton, { AnchorButtonProps } from '../anchor_button/AnchorButton';
+
+/**
+ * LabeledAnchorButton is an AnchorButton but designed to hold text.  It
+ * mirrors the Design of the LabeledButton, while being an Anchor tag for
+ * links instead of an actual button.
+ */
+const LabeledAnchorButton: React.FC<AnchorButtonProps> = (props) => (
+  <AnchorButton
+    {...props}
+    // eslint-disable-next-line react/prop-types
+    className={addClassToClassName(props.className, 'label type--ui--button')}
+  />
+);
+
+export default LabeledAnchorButton;

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/__docs__/LabeledAnchorButton.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/__docs__/LabeledAnchorButton.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Text from '../../../../text/Text';
+import LabeledAnchorButtonComp from '../LabeledAnchorButton';
+
+interface ExampleProps {
+  label: string;
+  disabled: boolean;
+  href: string;
+}
+
+const Example: React.FC<ExampleProps> = ({
+  label,
+  disabled,
+  href,
+  ...props
+}) => (
+  <LabeledAnchorButtonComp
+    {...props}
+    href={href}
+    disabled={disabled}
+    target="_blank"
+  >
+    <Text text={label} />
+  </LabeledAnchorButtonComp>
+);
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/HID/buttons/Labeled Anchor Button',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const LabeledAnchorButton: Story = {
+  args: {
+    disabled: false,
+    label: 'View All',
+    href: 'https://example.com/',
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/__test__/LabeledAnchorButton.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/__test__/LabeledAnchorButton.test.tsx
@@ -1,0 +1,35 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/LabeledAnchorButton.stories';
+
+const { LabeledAnchorButton } = composeStories(stories);
+
+describe('Labeled Anchor Button component', () => {
+  it('should render the Icon Button normally', async () => {
+    render(<LabeledAnchorButton data-testid="1" href="https://example.com/" />);
+    const link = screen.getByRole('link');
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', 'https://example.com/');
+
+    await userEvent.click(link);
+  });
+
+  it('should render Icon Button disabled', async () => {
+    render(
+      <LabeledAnchorButton
+        data-testid="1"
+        disabled
+        href="https://example.com/"
+      />,
+    );
+    const link = screen.getByTestId('1');
+    expect(link).toBeInTheDocument();
+    expect(link).not.toHaveAttribute('href');
+
+    await userEvent.click(link);
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_anchor_button/index.ts
@@ -1,0 +1,1 @@
+export { default as LabeledAnchorButton } from './LabeledAnchorButton';

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/LabeledButton.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/LabeledButton.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { addClassToClassName } from '../../../higher_order';
+import Button, { ButtonProps } from '../button/Button';
+
+/**
+ * LabeledButton is an extension to a normal Button, but designed to hold
+ * text specifically.  It has styles that provide sufficient padding and
+ * spacing as per the design specification.
+ */
+const LabeledButton: React.FC<ButtonProps> = ({ className, ...props }) => (
+  <Button
+    className={addClassToClassName(className, 'label type--ui--button')}
+    {...props}
+  />
+);
+
+export default LabeledButton;

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/__docs__/LabeledButton.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/__docs__/LabeledButton.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Text from '../../../../text/Text';
+import LabeledButtonComp from '../LabeledButton';
+
+interface ExampleProps {
+  label: string;
+  disabled: boolean;
+  onClick?: () => void;
+}
+
+const Example: React.FC<ExampleProps> = ({
+  label,
+  disabled,
+  onClick,
+  ...props
+}) => (
+  <LabeledButtonComp {...props} onClick={onClick} disabled={disabled}>
+    <Text text={label} />
+  </LabeledButtonComp>
+);
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/HID/buttons/Labeled Button',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const LabeledButton: Story = {
+  args: {
+    disabled: false,
+    onClick: () => {},
+    label: 'View All',
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/__test__/LabeledButton.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/__test__/LabeledButton.test.tsx
@@ -1,0 +1,37 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/LabeledButton.stories';
+
+const { LabeledButton } = composeStories(stories);
+
+describe('Labeled Button component', () => {
+  it('should render the Icon Button normally', async () => {
+    let a = 0;
+    render(<LabeledButton data-testid="1" onClick={() => (a = a + 1)} />);
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeEnabled();
+    expect(a).equals(0);
+
+    await userEvent.click(button);
+    expect(a).equals(1);
+  });
+
+  it('should render Icon Button disabled', async () => {
+    let a = 0;
+    render(
+      <LabeledButton data-testid="1" disabled onClick={() => (a = a + 1)} />,
+    );
+    const button = screen.getByRole('button');
+    expect(button).toBeInTheDocument();
+    expect(button).toBeDisabled();
+    expect(a).equals(0);
+
+    await userEvent.click(button);
+    expect(a).equals(0, 'tapping on a disabled button should have no result');
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/hid/buttons/labeled_button/index.ts
@@ -1,0 +1,1 @@
+export { default as LabeledButton } from './LabeledButton';


### PR DESCRIPTION
The design for buttons varies their padding and styles
depending on whether the content of the button is an icon
or text.  As such, we require the need for a distinction
between the two types.  There's nothing preventing the
misuse of these components, so this is something that
**should** be required knowledge when working with
these components.  A more specific document should
come indicating the reason for these button variations.

Closes #46