### PR TITLE
Add Social Media Links Component

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/links/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/links/index.ts
@@ -1,1 +1,2 @@
 export * from './link';
+export * from './social_media';

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/DiscordLink.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/DiscordLink.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import SocialMediaIconLink from './SocialMediaIconLink';
+import DiscordIcon from '../../visual/icons/DiscordIcon';
+
+/**
+ * DiscordLink is an icon link to the Espresso Discord server
+ */
+const DiscordLink: React.FC = () => (
+  <SocialMediaIconLink
+    href="https://discord.com/invite/DRfcHRnnBz"
+    title="Join the Espresso Discord"
+  >
+    <DiscordIcon />
+  </SocialMediaIconLink>
+);
+
+export default DiscordLink;

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/MediumLink.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/MediumLink.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import MediumIcon from '../../visual/icons/MediumIcon';
+import SocialMediaIconLink from './SocialMediaIconLink';
+
+/**
+ * MediumLink is an Icon Link to the Espresso Systems Medium Account
+ * @returns
+ */
+const MediumLink: React.FC = () => (
+  <SocialMediaIconLink
+    href="https://medium.com/@espressosys"
+    title="The Espresso Medium Account"
+  >
+    <MediumIcon />
+  </SocialMediaIconLink>
+);
+
+export default MediumLink;

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/SocialMediaIconLink.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/SocialMediaIconLink.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import Link from '../link/Link';
+import './social_media_icon_link.css';
+
+export interface SocialMediaIconLinkProps {
+  href: string;
+  title: string;
+  children: React.ReactNode | React.ReactNode[];
+}
+
+/**
+ * SocialMediaIconLink represents a Social Media Link to be placed within
+ * the footer element of a page.
+ */
+const SocialMediaIconLink: React.FC<SocialMediaIconLinkProps> = (props) => (
+  <Link
+    className="link--social"
+    href={props.href}
+    title={props.title}
+    target="_blank"
+  >
+    {props.children}
+  </Link>
+);
+
+export default SocialMediaIconLink;

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/SocialMediaLinks.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/SocialMediaLinks.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { addClassToClassName } from '../../higher_order';
+import DiscordLink from './DiscordLink';
+import MediumLink from './MediumLink';
+import TwitterLink from './TwitterLink';
+
+interface SocialMediaLinksProps
+  extends React.DetailedHTMLProps<
+    React.AnchorHTMLAttributes<HTMLDivElement>,
+    HTMLDivElement
+  > {}
+
+/**
+ * SocialMediaLinks is a component that contains the quick icon link references
+ * to all of the Espresso Social Media Links grouped together.
+ */
+const SocialMediaLinks: React.FC<SocialMediaLinksProps> = (props) => (
+  <div
+    {...props}
+    className={addClassToClassName(props.className, 'social-media-links')}
+  >
+    <DiscordLink />
+    <TwitterLink />
+    <MediumLink />
+  </div>
+);
+
+export default SocialMediaLinks;

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/TwitterLink.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/TwitterLink.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import TwitterIcon from '../../visual/icons/TwitterIcon';
+import SocialMediaIconLink from './SocialMediaIconLink';
+
+/**
+ * TwitterLink is an icon link to the Espresso Systems Twitter (X) account
+ */
+const TwitterLink: React.FC = () => (
+  <SocialMediaIconLink
+    href="https://twitter.com/EspressoSys"
+    title="Follow Espresso on X"
+  >
+    <TwitterIcon />
+  </SocialMediaIconLink>
+);
+
+export default TwitterLink;

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/__docs__/SocialMediaLinks.stories.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/__docs__/SocialMediaLinks.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import SocialMediaLinks from '../SocialMediaLinks';
+
+interface ExampleProps {}
+
+const Example: React.FC<ExampleProps> = (props) => (
+  <SocialMediaLinks {...props} />
+);
+
+const meta: Meta<typeof Example> = {
+  title: 'Components/Links/Social Media/Links',
+  component: Example,
+};
+
+export default meta;
+type Story = StoryObj<typeof Example>;
+
+export const Links: Story = {
+  args: {},
+  parameters: {
+    backgrounds: {
+      default: 'Footer',
+      values: [
+        {
+          name: 'Footer',
+          value: '#451f17ff',
+        },
+      ],
+    },
+  },
+};

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/__test__/SocialMediaLinks.test.tsx
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/__test__/SocialMediaLinks.test.tsx
@@ -1,0 +1,17 @@
+import { composeStories } from '@storybook/react';
+import '@testing-library/jest-dom';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import * as stories from '../__docs__/SocialMediaLinks.stories';
+
+const { Links } = composeStories(stories);
+
+describe('DataTable Component', async () => {
+  it('should have a link specified', async () => {
+    render(<Links data-testid="1" />);
+
+    const links = screen.getByTestId('1');
+    expect(links).toBeInTheDocument();
+  });
+});

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/index.ts
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/index.ts
@@ -1,0 +1,5 @@
+export { default as DiscordLink } from './DiscordLink';
+export { default as MediumLink } from './MediumLink';
+export { default as SocialMediaIconLink } from './SocialMediaIconLink';
+export { default as SocialMediaLinks } from './SocialMediaLinks';
+export { default as TwitterLink } from './TwitterLink';

--- a/packages/espresso-block-explorer-components/src/components/links/social_media/social_media_icon_link.css
+++ b/packages/espresso-block-explorer-components/src/components/links/social_media/social_media_icon_link.css
@@ -1,0 +1,8 @@
+a.link.link--social {
+  --icon--fill-color: var(--on-color--coffee);
+  padding: 10px;
+}
+
+a.link.link--social:hover {
+  --icon--fill-color: var(--color--caramel);
+}


### PR DESCRIPTION
The Block Explorer has a footer design that lists Espresso's
Social Media Links to indicate our Social Media presence.
These links are grouped together into a single element
containing all of these links.

Initially the design calls for Social Media Links for Medium,
Twitter, and Discord.

Closes #45