### PR TITLE
Rename Proposer to Builder

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/page_sections/block_detail_content/BlockDetailContent.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/block_detail_content/BlockDetailContent.tsx
@@ -126,7 +126,7 @@ export const BlockDetailsContentPlaceholder: React.FC<
         <SkeletonContent />
       </TableLabeledValue>
       <TableLabeledValue>
-        <Text text="Proposer" />
+        <Text text="Builder" />
         <SkeletonContent />
       </TableLabeledValue>
       <TableLabeledValue>
@@ -175,7 +175,7 @@ export const BlockDetailsContent: React.FC<BlockDetailsContentProps> = () => {
         </Link>
       </TableLabeledValue>
       <TableLabeledValue>
-        <Text text="Proposer" />
+        <Text text="Builder" />
         <CopyHex value={details.proposer}>
           <FullHexText value={details.proposer} />
         </CopyHex>

--- a/packages/espresso-block-explorer-components/src/components/page_sections/block_summary_data_table/BlockSummaryDataTable.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/block_summary_data_table/BlockSummaryDataTable.tsx
@@ -108,7 +108,7 @@ const BlockSummaryDataTableLayout: React.FC<
           buildCell: props.components[0],
         },
         {
-          label: 'Proposer',
+          label: 'Builder',
           columnType: BlockSummaryColumn.proposer,
           buildCell: props.components[1],
         },

--- a/packages/espresso-block-explorer-components/src/components/page_sections/latest_block_summary/LatestBlockSummary.tsx
+++ b/packages/espresso-block-explorer-components/src/components/page_sections/latest_block_summary/LatestBlockSummary.tsx
@@ -66,7 +66,7 @@ export const LatestBlockSummaryDetails: React.FC = () => {
         <NumberText number={block.transactions} />
       </SummaryTabledLabeledValue>
       <SummaryTabledLabeledValue>
-        <Text text="Proposer" />
+        <Text text="Builder" />
         <HexText value={block.proposer} />
       </SummaryTabledLabeledValue>
     </div>
@@ -89,7 +89,7 @@ export const LatestBlockSummaryDetailsPlaceholder: React.FC = () => {
         <SkeletonContent />
       </SummaryTabledLabeledValue>
       <SummaryTabledLabeledValue>
-        <Text text="Proposer" />
+        <Text text="Builder" />
         <SkeletonContent />
       </SummaryTabledLabeledValue>
     </div>


### PR DESCRIPTION
Closes #85
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
Replaces all occurrences of "Proposer" with "Builder" in order to more accurately represent what this value is.
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->

### This PR does not:
Rename the field in the underlying data structure.  This may need to be adjusted in a future release.
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->

### Key places to review:
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->
```sh
npm run storybook --workspace=packages/espresso-block-explorer-components
```

Then just view the pages to see all previous occurrences of "Proposer" being replaced with "Builder".
Relevant pages:
Explorer
Block Page

<!-- ### Things tested -->
<!-- Anything that was manually tested (that it is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
