### PR TITLE
Fix missing histogram y-axis labels

### DIFF
--- a/packages/espresso-block-explorer-components/src/components/visual/histogram/histogram_base/HistogramGuideLines.tsx
+++ b/packages/espresso-block-explorer-components/src/components/visual/histogram/histogram_base/HistogramGuideLines.tsx
@@ -51,6 +51,12 @@ export const ProvideGuideLines: React.FC<ProvideGuideLinesProps> = ({
   );
 };
 
+// the y-axis labels need an offset so that the lines don't overlap with the
+// labels as much as possible.  This number was chosen based on visual
+// inspection.  In an ideal circumstance the width of the labels would be
+// known and could be referenced.  For now this will suffice.
+const yAxisLabelOffset = 60;
+
 /**
  * HistogramGuidLines is a component that displays the guide lines for the y-axis
  * based on the sampling provided for the histogram.
@@ -72,7 +78,7 @@ export const HistogramGuideLines: React.FC = () => {
       {lines.map((line, i) => (
         <line
           key={i}
-          x1={60}
+          x1={yAxisLabelOffset}
           y1={plotHeight - rangeAffineTransform.transform(line)}
           x2={graphWidth}
           y2={plotHeight - rangeAffineTransform.transform(line)}


### PR DESCRIPTION
Closes #87
<!-- If there is no issue number make sure to describe clearly *why* this PR is necessary. -->
<!-- Mention open questions, remaining TODOs, if any -->

### This PR:
<!-- Describe what this PR adds to this repo and why -->
<!-- E.g. -->
<!-- * Implements feature 1 -->
<!-- * Fixes bug 3 -->
Adds better numeric resolution to the histogram y-axis labels for values that are less than a whole number.  Previously, if all the values of a histogram were between 0 and 1, the resulting histogram would have a single label for `0`, and nothing else.  This makes it difficult to reason about the scale of the histogram since no other labeled axis point exists.

### This PR does not:
<!-- Describe what is out of scope for this PR, if applicable. Leave this section blank if it's not applicable -->
<!-- This section helps avoid the reviewer having to needlessly point out missing parts -->
<!-- * Implement feature 3 because that feature is blocked by Issue 4 -->
<!-- * Implement xyz because that is tracked in issue #123. -->
<!-- * Address xzy for which I opened issue #456 -->
Add tooltips, or x-axis labels.  It also doesn't guarantee nicely readable / displayable values, or even have any preference towards whole numbers.  If this becomes problematic other strategies could be looked into in order to address this.

<!-- ### Key places to review: -->
<!-- Describe key places for reviewers to pay close attention to -->
<!-- * file.rs, `add_integers` function -->
<!-- Or directly comment on those files/lines to make it easier for the reviewers -->

### How to test this PR:
<!-- Optional, uncomment the above line if this is relevant to your PR -->
<!-- If your PR is fully tested through CI there is no need to add this section -->
<!-- * E.g. `just test` -->

```sh
npm run storybook --workspace=packages/espresso-block-explorer-components
```

There isn't an actual reproducible demonstrable way to reproduce this in the current demo.  What I've been doing to verify this is locally modifying packages/espresso-block-explorer-components/src/data_source/fake_data_source/generateFakeData.ts:87 to return between the range `0` and `2`.  This makes the Throughput histogram exhibit the behavior being addressed.

<!-- ### Things tested -->
<!-- Anything that was manually tested (that it is not tested in CI). -->
<!-- E.g. building/running of docker containers. Changes to docker demo, ... -->
<!-- Especially mention anything untested, with reasoning and link an issue to resolve this. -->

<!-- Complete the following items before creating this PR -->
<!-- [ ] Issue linked or PR description mentions why this change is necessary. -->
<!-- [ ] PR description is clear enough for reviewers. -->
<!-- [ ] If this is a draft it is marked as "draft".  -->

<!-- To make changes to this template edit https://github.com/EspressoSystems/.github/blob/main/PULL_REQUEST_TEMPLATE.md -->
